### PR TITLE
More UI improvements

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,8 +11,7 @@
 </head>
 
 <body>
-    <h1>SoWasm</h1>
-    <p>An RDF playground based on the <a href="https://crates.io/crates/sophia">Sophia</a> library.</p>
+    <p><b>SoWasm</b>: RDF playground based on the <a href="https://crates.io/crates/sophia">Sophia</a> library: validate, convert, or canonicalize RDF</p>
 
     <div id="iodiv">
         <div id="idiv">

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,10 +35,10 @@
             </div>
 
             <details id=advancedOptions>
-            <summary>Advanced options</summary>
-            <ul>
-                <li><label><input id="corsproxy" type="checkbox"> use <a href="https://corsproxy.io">corsproxy.io</a></label>
-            </ul>
+                <summary>Advanced options</summary>
+                <ul>
+                    <li><label><input id="corsproxy" type="checkbox"> use <a href="https://corsproxy.io">corsproxy.io</a></label>
+                </ul>
             </details>
         </div>
         <div id="odiv">

--- a/demo/index.html
+++ b/demo/index.html
@@ -29,9 +29,9 @@
             <div id="input"></div>
 
             <div class=toolbar>
-            <label for=url>URL:</label>
-            <input id="url">
-            <button id="load">load</button>
+                <label for=url>URL:</label>
+                <input id="url">
+                <button id="load">load</button>
             </div>
 
             <details id=advancedOptions>
@@ -62,17 +62,17 @@
         </div>
     </div>
     <div id=examples>
-    A few examples:
-    <ul>
-        <li><a href="?guess=&oformat=text%2Fturtle&auto=&input=%7B%0A++%22%40context%22%3A+%22https%3A%2F%2Fschema.org%2F%22%2C%0A++%22type%22%3A+%22Person%22%2C%0A++%22name%22%3A+%22Pierre-Antoine+Champin%22%2C%0A++%22url%22%3A+%22https%3A%2F%2Fchampin.net%2F%22%0A%7D">A simple JSON-LD example to Turtle</a>
-        <li><a href="?noguess=&iformat=text%2Fturtle&oformat=application%2Fcanonical-n-quads&auto=&url=https%3A%2F%2Fwww.w3.org%2FPeople%2FBerners-Lee%2Fcard.ttl">Tim Berners Lee's profile, from Turtle to Canonicalized RDF</a>
-        <li><a href="?noguess=&iformat=application%2Frdf%2Bxml&oformat=application%2Fld%2Bjson&auto=&url=https%3A%2F%2Fwww.w3.org%2FPeople%2FBerners-Lee%2Fcard.rdf">Tim Berners Lee's profile, from RDF/XML to JSON-LD</a>
-    </ul>
+        A few examples:
+        <ul>
+            <li><a href="?guess=&oformat=text%2Fturtle&auto=&input=%7B%0A++%22%40context%22%3A+%22https%3A%2F%2Fschema.org%2F%22%2C%0A++%22type%22%3A+%22Person%22%2C%0A++%22name%22%3A+%22Pierre-Antoine+Champin%22%2C%0A++%22url%22%3A+%22https%3A%2F%2Fchampin.net%2F%22%0A%7D">A simple JSON-LD example to Turtle</a>
+            <li><a href="?noguess=&iformat=text%2Fturtle&oformat=application%2Fcanonical-n-quads&auto=&url=https%3A%2F%2Fwww.w3.org%2FPeople%2FBerners-Lee%2Fcard.ttl">Tim Berners Lee's profile, from Turtle to Canonicalized RDF</a>
+            <li><a href="?noguess=&iformat=application%2Frdf%2Bxml&oformat=application%2Fld%2Bjson&auto=&url=https%3A%2F%2Fwww.w3.org%2FPeople%2FBerners-Lee%2Fcard.rdf">Tim Berners Lee's profile, from RDF/XML to JSON-LD</a>
+        </ul>
     </div>
     <footer>
         <p>Created by <a href="https://champin.net/">Pierre-Antoine Champin</a>
         —
-        <a href="https://github.com/pchampin/sowasm">Code available on github</a>
+        <a href="https://github.com/pchampin/sowasm">Code available on GitHub</a>
         </p>
     </footer>
 </body>

--- a/demo/style.css
+++ b/demo/style.css
@@ -53,6 +53,9 @@ h1 {
 #advancedOptions {
     margin-top: 0.5em;
 }
+details summary {
+    cursor: pointer;
+}
 
 #examples {
     margin-top: 0.5em;

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,4 +1,5 @@
 body {
+    font-family: sans-serif;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/demo/style.css
+++ b/demo/style.css
@@ -48,6 +48,7 @@ h1 {
 
 #url {
     flex-grow: 100;
+    margin: 0 0.5em;
 }
 
 #advancedOptions {

--- a/demo/style.css
+++ b/demo/style.css
@@ -20,8 +20,8 @@ h1 {
     gap: 1em;
 }
 
-/* Editors side by side on medium and large screens */
-@media (min-width: 51em) {
+/* Editors side by side on large screens */
+@media (min-width: 90em) {
     #iodiv {
         display: flex;
         flex-direction: row;
@@ -34,7 +34,7 @@ h1 {
 
 #input, #output {
     width: 100%;
-    height: 25em;
+    height: 70vh;
     margin-top: 0.5em;
 }
 


### PR DESCRIPTION
This PR follows up on https://github.com/pchampin/sowasm/pull/12 by making more consequent improvements to the UI

After a bit of usage it feels like having the 2 editors side by side on medium screen is really hard to read

The 1st example (JSON-LD) is readable, because really small. But the 2 others examples with XML are a pain to read

We should try to optimize the screen space used, I propose to:

* Integrate the "SoWasm" title in the intro paragraph
* Only put the editor side by side on large screens. From my experience I found it much more enjoyable to use it this way. It is nice to be able to properly read the RDF and edit it if necessary. Having the editors side by side don't have much advantages apart from being able to really quickly see or copy the converted RDF without the need to scroll
* Change the editor height to be `70vh`,  this will make the editors takes about 70% of the actual user screen, and prevents the editor from being bigger than the screen (which can be confusing). This way the editor are always large enough for users with medium to small screen, and they can better switch between the 2 editors (each editor takes most of the screen, which prevent confusion and improve focus). Editors also extend properly if the user have a large screen so they can make use of this awesome largeness and comfortably contemplate 2 large RDF files in one glance
